### PR TITLE
Prettier object deconstructing assignment error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ bin-release/
 # Other files and folders
 .settings/
 source/*
+.vscode/*
 
 # Executables
 *.swf

--- a/static/js/physics_engine.js
+++ b/static/js/physics_engine.js
@@ -13,7 +13,6 @@ class Entity {
         this.parentElem = parentElem;
 
         this.domInit();
-
     }
     get boundRect() {
         return this.domElem.getBoundingClientRect();
@@ -24,32 +23,32 @@ class Entity {
     }
 
     get coords() {
-        let [x, y] = [this.x, this.y]
+        let [x, y] = [this.x, this.y];
         return { x, y };
     }
-
 }
 
-Entity.prototype.domInit = function() {
+Entity.prototype.domInit = function () {
     this.domElem = document.createElement('div');
     this.domElem.classList.add('entity');
 
     if (this.color) this.domElem.style.backgroundColor = this.color;
 
     // attach element to get computed properties
-    this.parentElem.appendChild(this.domElem)
+    this.parentElem.appendChild(this.domElem);
 
     // get DOM computed coordinates and dimensions
     this.updateCoordsAndDimensions();
-}
+};
 
-Entity.prototype.newPosition = function(dx = 10) {
-
+Entity.prototype.newPosition = function (dx = 10) {
     dx = Number(dx);
     let absDx = Math.abs(dx);
     let maxDelta = 60;
     this.x += absDx < maxDelta ? dx : (dx / absDx) * maxDelta;
-    let { x: parentX, y: parentY, width: parentWidth, height: parentHeight } = this.parentBoundRect;
+
+    let { x:parentX, y:parentY, width:parentWidth, height:parentHeight } = this.parentBoundRect;
+
     if (this.x <= parentX) {
         this.x = parentX;
     } else if (this.x + this.width > parentX + parentWidth) {
@@ -57,26 +56,26 @@ Entity.prototype.newPosition = function(dx = 10) {
     }
     this.domElem.style.transform = `translateX(${this.x}px)`;
     console.log(this.x);
-}
+};
 
 // using DOM getBoundClientRect update Entity's props
-Entity.prototype.updateCoordsAndDimensions = function() {
+Entity.prototype.updateCoordsAndDimensions = function () {
     let { x, y, width, height } = this.boundRect;
     [this.x, this.y, this.width, this.height] = [x, y, width, height];
-    return ({ x, y, width, height })
-}
+    return { x, y, width, height };
+};
 
 // spaceCraft and Alien
 let spaceCraft = new Entity(playArea, 'purple');
 let Alien = new Entity(playArea, 'blue');
 
 // mouse Wheel capture
-window.addEventListener('wheel', onScrollEvent, { passive: true })
+window.addEventListener('wheel', onScrollEvent, { passive: true });
 
 let scroll;
 
 function onScrollEvent(event) {
     scroll = event;
     console.log(scroll);
-    spaceCraft.newPosition(dx = event.deltaY.toFixed(0))
+    spaceCraft.newPosition((dx = event.deltaY.toFixed(0)));
 }


### PR DESCRIPTION
Prettier creates a format "error" when dealing with the left-side deconstructing assignments. "A property can be unpacked from an object and assigned to a variable with a different name than the object property" 

i.e. let {a:aa} = {a: 5} \\ aa = 5

\\ prettier output
let {a: aa} = {a: 5}

Prettier adds a space in the left side assignment object {a:[--]aa} which Safari cannot handle.